### PR TITLE
CAPI-393 Fix: Export domains type

### DIFF
--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -39,6 +39,7 @@
 -export_type([token/0]).
 -export_type([expiration/0]).
 -export_type([domain_name/0]).
+-export_type([domains/0]).
 %%
 
 -type options() :: #{


### PR DESCRIPTION
Забыл экспортировать тип, а он нужен в `capi`.