### PR TITLE
FF-143: Rework token verification

### DIFF
--- a/src/uac.erl
+++ b/src/uac.erl
@@ -25,7 +25,7 @@
 }.
 
 -type verification_opts() :: #{
-    check_expired_as_of => genlib_time:ts()
+    claim_validators => uac_authorizer_jwt:validator()
 }.
 
 -type api_key() :: binary().


### PR DESCRIPTION
Разрешил выписывать токены без resource access клейма, добавил возможность не верифицировать такие токены и  в целом переработал систему валидации клеймов.