### PR TITLE
Verify tokens without resource_access

### DIFF
--- a/src/uac.erl
+++ b/src/uac.erl
@@ -81,6 +81,8 @@ authorize_api_key(bearer, Token, VerificationOpts) ->
 -spec authorize_operation(uac_conf:operation_access_scopes(), uac_authorizer_jwt:t()) ->
     ok | {error, unauthorized}.
 
+authorize_operation(_, {_, {_, undefined}, _}) ->
+    {error, unauthorized};
 authorize_operation(AccessScope, {_, {_SubjectID, ACL}, _}) ->
     case lists:all(
         fun ({Scope, Permission}) ->

--- a/src/uac.erl
+++ b/src/uac.erl
@@ -25,8 +25,7 @@
 }.
 
 -type verification_opts() :: #{
-    check_expired_as_of => genlib_time:ts(),
-    should_authorize_operations => boolean()
+    check_expired_as_of => genlib_time:ts()
 }.
 
 -type api_key() :: binary().

--- a/src/uac_acl.erl
+++ b/src/uac_acl.erl
@@ -152,8 +152,6 @@ match_scope(_, _) ->
 -spec decode([binary()]) ->
     t().
 
-decode(undefined) ->
-    undefined;
 decode(V) ->
     lists:foldl(fun decode_entry/2, new(), V).
 

--- a/src/uac_acl.erl
+++ b/src/uac_acl.erl
@@ -152,6 +152,8 @@ match_scope(_, _) ->
 -spec decode([binary()]) ->
     t().
 
+decode(undefined) ->
+    undefined;
 decode(V) ->
     lists:foldl(fun decode_entry/2, new(), V).
 

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -235,9 +235,8 @@ sign(#{kid := KID, jwk := JWK, signer := #{} = JWS}, Claims) ->
         invalid_signature
     }.
 
-verify(Token, VerificationOpts0) ->
+verify(Token, VerificationOpts) ->
     try
-        VerificationOpts = maps:merge(#{should_authorize_operations => true}, VerificationOpts0),
         {_, ExpandedToken} = jose_jws:expand(Token),
         #{<<"protected">> := ProtectedHeader} = ExpandedToken,
         Header = base64url_to_map(ProtectedHeader),
@@ -270,7 +269,7 @@ verify(JWK, ExpandedToken, VerificationOpts) ->
     case jose_jwt:verify(JWK, ExpandedToken) of
         {true, #jose_jwt{fields = Claims}, _JWS} ->
             {KeyMeta, Claims1} = validate_claims(Claims, VerificationOpts),
-            get_result(KeyMeta, decode_roles(Claims1, VerificationOpts));
+            get_result(KeyMeta, decode_roles(Claims1));
         {false, _JWT, _JWS} ->
             {error, invalid_signature}
     end.
@@ -370,18 +369,18 @@ encode_roles(DomainRoles) when is_map(DomainRoles) andalso map_size(DomainRoles)
 encode_roles(_) ->
     #{}.
 
-decode_roles(Claims, #{should_authorize_operations := true}) ->
-    case maps:get(<<"resource_access">>, Claims, undefined) of
+decode_roles(Claims) ->
+    Roles = case maps:get(<<"resource_access">>, Claims, undefined) of
         Resources when is_map(Resources) andalso map_size(Resources) > 0 ->
             Accepted = uac_conf:get_domain_name(),
-            Roles = try_get_roles(Resources, Accepted),
-            {Roles, maps:remove(<<"resource_access">>, Claims)};
+           try_get_roles(Resources, Accepted);
+        undefined ->
+            undefined;
         _ ->
+            % Resources is not map or an empty one
             throw({invalid_token, {missing, acl}})
-    end;
-decode_roles(Claims, _) ->
-    % don't even bother looking for roles
-    {[], Claims}.
+    end,
+    {Roles, maps:remove(<<"resource_access">>, Claims)}.
 
 try_get_roles(Resources, Accepted) ->
     case maps:get(Accepted, Resources, undefined) of

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -383,7 +383,7 @@ decode_roles(Claims) ->
             undefined;
         _ ->
             % Resources is not map or an empty one
-            throw({invalid_token, {missing, acl}})
+            throw({invalid_token, {invalid, acl}})
     end,
     {Roles, maps:remove(<<"resource_access">>, Claims)}.
 

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -286,12 +286,17 @@ validate_claims(Claims, [], _, Acc) ->
 get_result(KeyMeta, {Roles, Claims}) ->
     #{token_id := TokenID, subject_id := SubjectID} = KeyMeta,
     try
-        Subject = {SubjectID, uac_acl:decode(Roles)},
+        Subject = {SubjectID, try_decode_roles(Roles)},
         {ok, {TokenID, Subject, Claims}}
     catch
         error:{badarg, _} = Reason ->
             throw({invalid_token, {malformed_acl, Reason}})
     end.
+
+try_decode_roles(undefined) ->
+    undefined;
+try_decode_roles(Roles0) ->
+    uac_acl:decode(Roles0).
 
 get_kid(#{<<"kid">> := KID}) when is_binary(KID) ->
     KID;

--- a/test/uac_tests_SUITE.erl
+++ b/test/uac_tests_SUITE.erl
@@ -20,7 +20,7 @@
     different_issuers_test/1,
     unknown_resources_ok_test/1,
     unknown_resources_fail_encode_test/1,
-    undefined_ACL_in_token_with_no_resource_access/1
+    undefined_acl_in_token_without_resource_access/1
 ]).
 
 -type test_case_name()  :: atom().
@@ -192,9 +192,9 @@ unknown_resources_ok_test(_) ->
     {ok, AccessContext} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}),
     ok = uac:authorize_operation(?TEST_SERVICE_ACL(write), AccessContext).
 
--spec undefined_ACL_in_token_with_no_resource_access(config()) ->
+-spec undefined_acl_in_token_without_resource_access(config()) ->
     _.
-undefined_ACL_in_token_with_no_resource_access(_) ->
+undefined_acl_in_token_without_resource_access(_) ->
     {ok, Token} = issue_token(#{}, unlimited),
     {ok, {_, {_, undefined}, _}} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}).
 

--- a/test/uac_tests_SUITE.erl
+++ b/test/uac_tests_SUITE.erl
@@ -51,7 +51,7 @@ all() ->
         unknown_resources_ok_test,
         unknown_resources_fail_encode_test,
         different_issuers_test,
-        undefined_ACL_in_token_with_no_resource_access
+        undefined_acl_in_token_without_resource_access
     ].
 
 -spec init_per_suite(config()) ->

--- a/test/uac_tests_SUITE.erl
+++ b/test/uac_tests_SUITE.erl
@@ -20,7 +20,7 @@
     different_issuers_test/1,
     unknown_resources_ok_test/1,
     unknown_resources_fail_encode_test/1,
-    cant_authorize_without_resource_access/1
+    undefined_ACL_in_token_with_no_resource_access/1
 ]).
 
 -type test_case_name()  :: atom().
@@ -51,7 +51,7 @@ all() ->
         unknown_resources_ok_test,
         unknown_resources_fail_encode_test,
         different_issuers_test,
-        cant_authorize_without_resource_access
+        undefined_ACL_in_token_with_no_resource_access
     ].
 
 -spec init_per_suite(config()) ->
@@ -192,11 +192,11 @@ unknown_resources_ok_test(_) ->
     {ok, AccessContext} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}),
     ok = uac:authorize_operation(?TEST_SERVICE_ACL(write), AccessContext).
 
--spec cant_authorize_without_resource_access(config()) ->
+-spec undefined_ACL_in_token_with_no_resource_access(config()) ->
     _.
-cant_authorize_without_resource_access(_) ->
+undefined_ACL_in_token_with_no_resource_access(_) ->
     {ok, Token} = issue_token(#{}, unlimited),
-    {error, {invalid_token,{missing,acl}}} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}).
+    {ok, {_, {_, undefined}, _}} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}).
 
 -spec unknown_resources_fail_encode_test(config()) ->
     _.


### PR DESCRIPTION
Подумал над комментариями к https://github.com/rbkmoney/fistful-server/pull/165

Родилось решение, позволящее верифицировать токены вне зависимости от наличия `<<"resource_access">>` не указывая никаких флагов верификации. Если такого клейма нет, то в ACL возвращается undefined, как распоряжаться этим значением остается на совести пользователя.