### PR TITLE
MSPF-535: Return domains

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ build('erlang_uac', 'docker-host', finalHook) {
       sh 'make wc_xref'
     }
     runStage('dialyze') {
-      withWsCache("_build/default/rebar3_19.3_plt") {
+      withWsCache("_build/default/rebar3_21.3.8.4_plt") {
         sh 'make wc_dialyze'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ build('erlang_uac', 'docker-host', finalHook) {
       sh 'make wc_xref'
     }
     runStage('dialyze') {
-      withWsCache("_build/default/rebar3_21.3.8.4_plt") {
+      withWsCache("_build/default/rebar3_22.2.6_plt") {
         sh 'make wc_dialyze'
       }
     }

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TEMPLATES_PATH := .
 # Name of the service
 SERVICE_NAME := erlang_uac
 
-BUILD_IMAGE_TAG := c66dc597fdc30abcb7a6368ba7cc13c02151f8de
+BUILD_IMAGE_TAG := e7eb72b7721443d88a948546da815528a96c6de9
 
 CALL_ANYWHERE := \
 	submodules \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TEMPLATES_PATH := .
 # Name of the service
 SERVICE_NAME := erlang_uac
 
-BUILD_IMAGE_TAG := 562313697353c29d4b34fb081a8b70e8c2207134
+BUILD_IMAGE_TAG := c66dc597fdc30abcb7a6368ba7cc13c02151f8de
 
 CALL_ANYWHERE := \
 	submodules \

--- a/src/uac.erl
+++ b/src/uac.erl
@@ -112,8 +112,7 @@ authorize_operation_(AccessScope, ACL) ->
 get_acl(Claims, Domain) ->
     case genlib_map:get(<<"resource_access">>, Claims) of
         undefined -> undefined;
-        DomainRoles when is_map(DomainRoles) -> genlib_map:get(Domain, DomainRoles);
-        _ -> undefined
+        DomainRoles when is_map(DomainRoles) -> genlib_map:get(Domain, DomainRoles)
     end.
 
 %%

--- a/src/uac.erl
+++ b/src/uac.erl
@@ -90,8 +90,9 @@ authorize_operation(AccessScope, Context) ->
     ok | {error, unauthorized}.
 authorize_operation(_, {_, {_, undefined}, _}, _) ->
     {error, unauthorized};
-authorize_operation(AccessScope, {_, {_SubjectID, DomainRoles}, _}, Domain) ->
-    authorize_operation_(AccessScope, genlib_map:get(Domain, DomainRoles)).
+authorize_operation(AccessScope, {_, _, Claims}, Domain) ->
+    ACL = get_acl(Claims, Domain),
+    authorize_operation_(AccessScope, ACL).
 
 authorize_operation_(_, undefined) ->
     {error, unauthorized};
@@ -106,6 +107,13 @@ authorize_operation_(AccessScope, ACL) ->
             ok;
         false ->
             {error, unauthorized}
+    end.
+
+get_acl(Claims, Domain) ->
+    case genlib_map:get(<<"resource_access">>, Claims) of
+        undefined -> undefined;
+        DomainRoles when is_map(DomainRoles) -> genlib_map:get(Domain, DomainRoles);
+        _ -> undefined
     end.
 
 %%

--- a/src/uac.erl
+++ b/src/uac.erl
@@ -88,8 +88,6 @@ authorize_operation(AccessScope, Context) ->
 
 -spec authorize_operation(uac_conf:operation_access_scopes(), context(), domain_name()) ->
     ok | {error, unauthorized}.
-authorize_operation(_, {_, {_, undefined}, _}, _) ->
-    {error, unauthorized};
 authorize_operation(AccessScope, {_, _, Claims}, Domain) ->
     ACL = get_acl(Claims, Domain),
     authorize_operation_(AccessScope, ACL).

--- a/src/uac.erl
+++ b/src/uac.erl
@@ -94,7 +94,7 @@ authorize_operation(AccessScope, {_, {_SubjectID, DomainRoles}, _}, Domain) ->
     authorize_operation_(AccessScope, genlib_map:get(Domain, DomainRoles)).
 
 authorize_operation_(_, undefined) ->
-    {error, undefined};
+    {error, unauthorized};
 authorize_operation_(AccessScope, ACL) ->
     case lists:all(
         fun ({Scope, Permission}) ->

--- a/src/uac.erl
+++ b/src/uac.erl
@@ -15,6 +15,7 @@
 -export([configure/1]).
 -export([authorize_api_key/2]).
 -export([authorize_operation/2]).
+-export([authorize_operation/3]).
 
 -type context() :: uac_authorizer_jwt:t().
 -type claims()  :: uac_authorizer_jwt:claims().
@@ -28,8 +29,9 @@
     check_expired_as_of => genlib_time:ts()
 }.
 
--type api_key() :: binary().
--type key_type() :: bearer.
+-type api_key()     :: binary().
+-type key_type()    :: bearer.
+-type domain_name() :: uac_authorizer_jwt:domain_name().
 
 -export_type([context/0]).
 -export_type([claims/0]).
@@ -78,12 +80,22 @@ authorize_api_key(bearer, Token, VerificationOpts) ->
 
 %%
 
--spec authorize_operation(uac_conf:operation_access_scopes(), uac_authorizer_jwt:t()) ->
+-spec authorize_operation(uac_conf:operation_access_scopes(), context()) ->
     ok | {error, unauthorized}.
 
-authorize_operation(_, {_, {_, undefined}, _}) ->
+authorize_operation(AccessScope, Context) ->
+    authorize_operation(AccessScope, Context, uac_conf:get_domain_name()).
+
+-spec authorize_operation(uac_conf:operation_access_scopes(), context(), domain_name()) ->
+    ok | {error, unauthorized}.
+authorize_operation(_, {_, {_, undefined}, _}, _) ->
     {error, unauthorized};
-authorize_operation(AccessScope, {_, {_SubjectID, ACL}, _}) ->
+authorize_operation(AccessScope, {_, {_SubjectID, DomainRoles}, _}, Domain) ->
+    authorize_operation_(AccessScope, genlib_map:get(Domain, DomainRoles)).
+
+authorize_operation_(_, undefined) ->
+    {error, undefined};
+authorize_operation_(AccessScope, ACL) ->
     case lists:all(
         fun ({Scope, Permission}) ->
             lists:member(Permission, uac_acl:match(Scope, ACL))

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -345,7 +345,7 @@ get_check_expiry(Opts) ->
 
 -spec get_subject_id(t()) -> binary().
 
-get_subject_id({_Id, {SubjectID, _ACL}, _Claims}) ->
+get_subject_id({_Id, SubjectID, _Claims}) ->
     SubjectID.
 
 -spec get_claims(t()) -> claims().

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -28,10 +28,9 @@
 -type kid()          :: binary().
 -type key()          :: #jose_jwk{}.
 -type token()        :: binary().
--type claims()       :: #{binary() => term()}.
--type subject()      :: {subject_id(), domains() | undefined}.
+-type claims()       :: #{binary() => domains() | term()}.
 -type subject_id()   :: binary().
--type t()            :: {id(), subject(), claims()}.
+-type t()            :: {id(), subject_id(), claims()}.
 -type domain_name()  :: binary().
 -type domains()      :: #{domain_name() => uac_acl:t()}.
 -type expiration()        ::
@@ -41,7 +40,6 @@
 -type id() :: binary().
 
 -export_type([t/0]).
--export_type([subject/0]).
 -export_type([claims/0]).
 -export_type([token/0]).
 -export_type([expiration/0]).

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -320,8 +320,11 @@ check_expiration(_, Exp, Opts) when is_integer(Exp) ->
         _ ->
             throw({invalid_token, expired})
     end;
-check_expiration(_, undefined, _) ->
-    undefined;
+check_expiration(C, undefined, Opts) ->
+    case get_check_expiry(Opts) of
+        {true, _} -> throw({invalid_token, {missing, C}});
+        false     -> undefined
+    end;
 check_expiration(C, V, _) ->
     throw({invalid_token, {badarg, {C, V}}}).
 

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -366,7 +366,6 @@ get_claim(ClaimName, {_Id, _Subject, Claims}, Default) ->
 %%
 
 encode_roles(DomainRoles) when is_map(DomainRoles) andalso map_size(DomainRoles) > 0 ->
-    % do we really want to add <<"roles">>?
     F = fun(_, Roles) -> #{<<"roles">> => uac_acl:encode(Roles)} end,
     maps:map(F, DomainRoles);
 encode_roles(_) ->

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -29,7 +29,7 @@
 -type key()          :: #jose_jwk{}.
 -type token()        :: binary().
 -type claims()       :: #{binary() => term()}.
--type subject()      :: {subject_id(), uac_acl:t()}.
+-type subject()      :: {subject_id(), uac_acl:t() | undefined}.
 -type subject_id()   :: binary().
 -type t()            :: {id(), subject(), claims()}.
 -type domain_name()  :: binary().

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -170,7 +170,11 @@ construct_key(KID, JWK) ->
 
 issue(JTI, Expiration, {SubjectID, ACL}, Claims, Signee) ->
     Domain = uac_conf:get_domain_name(),
-    issue(JTI, Expiration, SubjectID, #{Domain => ACL}, Claims, Signee).
+    DomainRoles = case ACL of
+        undefined -> #{};
+        ACL -> #{Domain => ACL}
+    end,
+    issue(JTI, Expiration, SubjectID, DomainRoles, Claims, Signee).
 
 -spec issue(id(), expiration(), subject_id(), domains(), claims(), keyname()) ->
     {ok, token()} |

--- a/test/uac_tests_SUITE.erl
+++ b/test/uac_tests_SUITE.erl
@@ -148,8 +148,9 @@ force_expiration_fail_test(_) ->
     _.
 bad_signee_test(_) ->
     ACL = ?TEST_SERVICE_ACL(write),
+    Claims = uac_authorizer_jwt:create_claims(#{}, unlimited, #{?TEST_DOMAIN_NAME => uac_acl:from_list(ACL)}),
     {error, nonexistent_key} =
-        uac_authorizer_jwt:issue(unique_id(), unlimited, {<<"TEST">>, uac_acl:from_list(ACL)}, #{}, random).
+        uac_authorizer_jwt:issue(unique_id(), <<"TEST">>, Claims, random).
 
 %%
 
@@ -189,18 +190,15 @@ unknown_resources_fail_encode_test(_) ->
 
 issue_token(DomainRoles, LifeTime) when is_map(DomainRoles) ->
     PartyID = <<"TEST">>,
-    Claims = #{<<"TEST">> => <<"TEST">>},
-    uac_authorizer_jwt:issue(unique_id(), LifeTime, PartyID, DomainRoles, Claims, test);
+    Claims0 = #{<<"TEST">> => <<"TEST">>},
+    Claims = uac_authorizer_jwt:create_claims(Claims0, LifeTime, DomainRoles),
+    uac_authorizer_jwt:issue(unique_id(), PartyID, Claims, test);
 
 issue_token(ACL, LifeTime) ->
     PartyID = <<"TEST">>,
-    Claims = #{
-        <<"TEST">> => <<"TEST">>,
-        <<"resource_access">> => #{
-            ?TEST_DOMAIN_NAME => uac_acl:from_list(ACL)
-        }
-    },
-    uac_authorizer_jwt:issue(unique_id(), LifeTime, PartyID, Claims, test).
+    Claims0 = #{<<"TEST">> => <<"TEST">>},
+    Claims = uac_authorizer_jwt:create_claims(Claims0, LifeTime, #{?TEST_DOMAIN_NAME => uac_acl:from_list(ACL)}),
+    uac_authorizer_jwt:issue(unique_id(), PartyID, Claims, test).
 
 issue_dummy_token(ACL, Config) ->
     Claims = #{

--- a/test/uac_tests_SUITE.erl
+++ b/test/uac_tests_SUITE.erl
@@ -17,7 +17,6 @@
     force_expiration_test/1,
     force_expiration_fail_test/1,
     bad_signee_test/1,
-    different_issuers_test/1,
     unknown_resources_ok_test/1,
     unknown_resources_fail_encode_test/1,
     undefined_acl_in_token_without_resource_access/1
@@ -50,7 +49,6 @@ all() ->
         bad_signee_test,
         unknown_resources_ok_test,
         unknown_resources_fail_encode_test,
-        different_issuers_test,
         undefined_acl_in_token_without_resource_access
     ].
 
@@ -159,18 +157,6 @@ bad_signee_test(_) ->
         uac_authorizer_jwt:issue(unique_id(), unlimited, {<<"TEST">>, uac_acl:from_list(ACL)}, #{}, random).
 
 %%
-
--spec different_issuers_test(config()) ->
-    _.
-different_issuers_test(_) ->
-    {ok, Token} = issue_token(?TEST_SERVICE_ACL(write), unlimited),
-    ok = uac_conf:configure(#{
-        domain_name => <<"SOME_OTHER_SERVICE">>
-    }),
-    {ok, {_, {_, []}, _}} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}),
-    ok = uac_conf:configure(#{
-        domain_name => ?TEST_DOMAIN_NAME
-    }).
 
 -spec unknown_resources_ok_test(config()) ->
     _.


### PR DESCRIPTION
uac больше не возвращает ACL отдельно, оставляя его внутри `resource_access` клейма. Для удобства клиента, он научился принимать клеймы при авторизации операции