### PR TITLE
CAPI-418: Specify domains to decode

### DIFF
--- a/src/uac.erl
+++ b/src/uac.erl
@@ -27,7 +27,7 @@
 
 -type verification_opts() :: #{
     check_expired_as_of => genlib_time:ts(),
-    domains => [domain_name()]
+    domains_to_decode => [domain_name()]
 }.
 
 -type api_key()     :: binary().

--- a/src/uac.erl
+++ b/src/uac.erl
@@ -26,7 +26,8 @@
 }.
 
 -type verification_opts() :: #{
-    check_expired_as_of => genlib_time:ts()
+    check_expired_as_of => genlib_time:ts(),
+    domains => [domain_name()]
 }.
 
 -type api_key()     :: binary().

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -262,7 +262,7 @@ verify(JWK, ExpandedToken, VerificationOpts) ->
     case jose_jwt:verify(JWK, ExpandedToken) of
         {true, #jose_jwt{fields = Claims}, _JWS} ->
             {KeyMeta, Claims1} = validate_claims(Claims, VerificationOpts),
-            get_result(KeyMeta, Claims1);
+            get_result(KeyMeta, Claims1, VerificationOpts);
         {false, _JWT, _JWS} ->
             {error, invalid_signature}
     end.
@@ -276,10 +276,10 @@ validate_claims(Claims, [{Name, Claim, Validator} | Rest], VerificationOpts, Acc
 validate_claims(Claims, [], _, Acc) ->
     {Acc, Claims}.
 
-get_result(KeyMeta, Claims) ->
+get_result(KeyMeta, Claims, VerificationOpts) ->
     #{token_id := TokenID, subject_id := SubjectID} = KeyMeta,
     try
-        {ok, {TokenID, SubjectID, decode_roles(Claims)}}
+        {ok, {TokenID, SubjectID, decode_roles(Claims, VerificationOpts)}}
     catch
         error:{badarg, _} = Reason ->
             throw({invalid_token, {malformed_acl, Reason}})
@@ -372,12 +372,16 @@ encode_roles(DomainRoles) when is_map(DomainRoles) andalso map_size(DomainRoles)
 encode_roles(_) ->
     #{}.
 
-decode_roles(Claims) ->
+decode_roles(Claims, VerificationOpts) ->
     case genlib_map:get(<<"resource_access">>, Claims) of
         undefined ->
             Claims;
         ResourceAcceess when is_map(ResourceAcceess) ->
-            DomainRoles = maps:map(fun(_, #{<<"roles">> := Roles}) -> uac_acl:decode(Roles) end, ResourceAcceess),
+            Domains = maps:get(domains, VerificationOpts, maps:keys(ResourceAcceess)),
+            DomainRoles = maps:map(
+                fun(_, #{<<"roles">> := Roles}) -> uac_acl:decode(Roles) end,
+                maps:with(Domains, ResourceAcceess)
+            ),
             Claims#{<<"resource_access">> => DomainRoles};
         _ ->
             throw({invalid_token, {invalid, acl}})

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -377,7 +377,7 @@ decode_roles(Claims, VerificationOpts) ->
         undefined ->
             Claims;
         ResourceAcceess when is_map(ResourceAcceess) ->
-            Domains = maps:get(domains, VerificationOpts, maps:keys(ResourceAcceess)),
+            Domains = maps:get(domains_to_decode, VerificationOpts, maps:keys(ResourceAcceess)),
             DomainRoles = maps:map(
                 fun(_, #{<<"roles">> := Roles}) -> uac_acl:decode(Roles) end,
                 maps:with(Domains, ResourceAcceess)

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -377,6 +377,8 @@ decode_roles(Claims, VerificationOpts) ->
         undefined ->
             Claims;
         ResourceAcceess when is_map(ResourceAcceess) ->
+            % @FIXME This is a temporary solution
+            % rework interface the way this line won't be needed
             Domains = maps:get(domains_to_decode, VerificationOpts, maps:keys(ResourceAcceess)),
             DomainRoles = maps:map(
                 fun(_, #{<<"roles">> := Roles}) -> uac_acl:decode(Roles) end,

--- a/test/uac_tests_SUITE.erl
+++ b/test/uac_tests_SUITE.erl
@@ -20,7 +20,8 @@
     unknown_resources_ok_test/1,
     unknown_resources_fail_encode_test/1,
     cant_authorize_without_resource_access/1,
-    no_expiration_claim_allowed/1
+    no_expiration_claim_allowed/1,
+    configure_processed_domains_test/1
 ]).
 
 -type test_case_name()  :: atom().
@@ -51,8 +52,8 @@ all() ->
         unknown_resources_ok_test,
         unknown_resources_fail_encode_test,
         cant_authorize_without_resource_access,
-        no_expiration_claim_allowed
-
+        no_expiration_claim_allowed,
+        configure_processed_domains_test
     ].
 
 -spec init_per_suite(config()) ->
@@ -195,6 +196,21 @@ no_expiration_claim_allowed(_) ->
     PartyID = <<"TEST">>,
     {ok, Token} = uac_authorizer_jwt:issue(unique_id(), PartyID, #{}, test),
     {ok, _} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}).
+
+-spec configure_processed_domains_test(config()) ->
+    _.
+
+configure_processed_domains_test(_) ->
+    ACL = ?TEST_SERVICE_ACL(read),
+    Domain1  = <<"api-1">>,
+    Domain2  = <<"api-2">>,
+    {ok, Token} = issue_token(#{
+        Domain1 => uac_acl:from_list(ACL),
+        Domain2 => uac_acl:from_list(ACL)
+    }, unlimited),
+    {ok, AccessContext} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{domains => [Domain1]}),
+    ok = uac:authorize_operation([], AccessContext, Domain1),
+    {error, unauthorized} = uac:authorize_operation([], AccessContext, Domain2).
 
 %%
 

--- a/test/uac_tests_SUITE.erl
+++ b/test/uac_tests_SUITE.erl
@@ -208,7 +208,7 @@ configure_processed_domains_test(_) ->
         Domain1 => uac_acl:from_list(ACL),
         Domain2 => uac_acl:from_list(ACL)
     }, unlimited),
-    {ok, AccessContext} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{domains => [Domain1]}),
+    {ok, AccessContext} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{domains_to_decode => [Domain1]}),
     ok = uac:authorize_operation([], AccessContext, Domain1),
     {error, unauthorized} = uac:authorize_operation([], AccessContext, Domain2).
 


### PR DESCRIPTION
Временный (хах!) фикс проблемы с чтением ролей, которые `uac` физически не может и кажется не должен уметь декодировать. Позволяет при верификации токена специфицировать какие домены будут декодированы, остальные будут пропущены. Если опция не задана, то  декодируются роли всех доменов