### PR TITLE
MSPF-608: Drop implicit access claim decoding on verify

### DIFF
--- a/src/uac.erl
+++ b/src/uac.erl
@@ -96,8 +96,6 @@ authorize_operation(AccessScope, Context, Domain) ->
             {error, {acl, Reason}}
     end.
 
-authorize_operation_(_, undefined) ->
-    {error, unauthorized};
 authorize_operation_(AccessScope, ACL) ->
     case
         lists:all(

--- a/src/uac_authorizer_jwt.erl
+++ b/src/uac_authorizer_jwt.erl
@@ -17,6 +17,7 @@
 -export([get_subject_email/1]).
 -export([set_subject_email/2]).
 -export([get_expires_at/1]).
+-export([get_acl/1]).
 -export([get_acl/2]).
 
 -export([get_subject_id/1]).
@@ -408,6 +409,10 @@ get_subject_email(T) ->
 set_subject_email(SubjectID, Claims) ->
     false = maps:is_key(?CLAIM_SUBJECT_EMAIL, Claims),
     Claims#{?CLAIM_SUBJECT_EMAIL => SubjectID}.
+
+-spec get_acl(t()) -> {ok, uac_acl:t()} | {error, missing | {invalid, _Reason}}.
+get_acl(Context) ->
+    get_acl(uac_conf:get_domain_name(), Context).
 
 -spec get_acl(domain_name(), t()) -> {ok, uac_acl:t()} | {error, missing | {invalid, _Reason}}.
 get_acl(Domain, {_Id, _Subject, Claims, _Metadata}) ->

--- a/test/uac_tests_SUITE.erl
+++ b/test/uac_tests_SUITE.erl
@@ -20,8 +20,7 @@
     unknown_resources_ok_test/1,
     unknown_resources_fail_encode_test/1,
     cant_authorize_without_resource_access/1,
-    no_expiration_claim_allowed/1,
-    multiple_domains_test/1
+    no_expiration_claim_allowed/1
 ]).
 
 -type test_case_name() :: atom().
@@ -49,8 +48,7 @@ all() ->
         unknown_resources_ok_test,
         unknown_resources_fail_encode_test,
         cant_authorize_without_resource_access,
-        no_expiration_claim_allowed,
-        multiple_domains_test
+        no_expiration_claim_allowed
     ].
 
 -spec init_per_suite(config()) -> config().
@@ -188,22 +186,6 @@ no_expiration_claim_allowed(_) ->
     PartyID = <<"TEST">>,
     {ok, Token} = uac_authorizer_jwt:issue(unique_id(), PartyID, #{}, test),
     {ok, _} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}).
-
--spec multiple_domains_test(config()) -> _.
-multiple_domains_test(_) ->
-    ACL = ?TEST_SERVICE_ACL(read),
-    Domain1 = <<"api-1">>,
-    Domain2 = <<"api-2">>,
-    {ok, Token} = issue_token(
-        #{
-            Domain1 => uac_acl:from_list(ACL),
-            Domain2 => uac_acl:from_list(ACL)
-        },
-        unlimited
-    ),
-    {ok, AccessContext} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}),
-    ok = uac:authorize_operation([], AccessContext, Domain1),
-    {error, unauthorized} = uac:authorize_operation(?TEST_SERVICE_ACL(write), AccessContext, Domain2).
 
 %%
 

--- a/test/uac_tests_SUITE.erl
+++ b/test/uac_tests_SUITE.erl
@@ -21,7 +21,7 @@
     unknown_resources_fail_encode_test/1,
     cant_authorize_without_resource_access/1,
     no_expiration_claim_allowed/1,
-    configure_processed_domains_test/1
+    multiple_domains_test/1
 ]).
 
 -type test_case_name() :: atom().
@@ -50,7 +50,7 @@ all() ->
         unknown_resources_fail_encode_test,
         cant_authorize_without_resource_access,
         no_expiration_claim_allowed,
-        configure_processed_domains_test
+        multiple_domains_test
     ].
 
 -spec init_per_suite(config()) -> config().
@@ -176,7 +176,7 @@ unknown_resources_ok_test(_) ->
 cant_authorize_without_resource_access(_) ->
     {ok, Token} = issue_token(#{}, unlimited),
     {ok, AccessContext} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}),
-    {error, unauthorized} = uac:authorize_operation([], AccessContext).
+    {error, {acl, missing}} = uac:authorize_operation([], AccessContext).
 
 -spec unknown_resources_fail_encode_test(config()) -> _.
 unknown_resources_fail_encode_test(_) ->
@@ -189,8 +189,8 @@ no_expiration_claim_allowed(_) ->
     {ok, Token} = uac_authorizer_jwt:issue(unique_id(), PartyID, #{}, test),
     {ok, _} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}).
 
--spec configure_processed_domains_test(config()) -> _.
-configure_processed_domains_test(_) ->
+-spec multiple_domains_test(config()) -> _.
+multiple_domains_test(_) ->
     ACL = ?TEST_SERVICE_ACL(read),
     Domain1 = <<"api-1">>,
     Domain2 = <<"api-2">>,
@@ -201,9 +201,9 @@ configure_processed_domains_test(_) ->
         },
         unlimited
     ),
-    {ok, AccessContext} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{domains_to_decode => [Domain1]}),
+    {ok, AccessContext} = uac:authorize_api_key(<<"Bearer ", Token/binary>>, #{}),
     ok = uac:authorize_operation([], AccessContext, Domain1),
-    {error, unauthorized} = uac:authorize_operation([], AccessContext, Domain2).
+    {error, unauthorized} = uac:authorize_operation(?TEST_SERVICE_ACL(write), AccessContext, Domain2).
 
 %%
 


### PR DESCRIPTION
Given the prospect of moving authz responsibility to the bouncer and token-keeper duo we should anticipate missing `resource_access` claim in tokens, which is implicitly required right now. Besides, this PR removes dubious interface details, namely `domains_to_decode` option.